### PR TITLE
Add yolo weights check file to DockerFile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -231,7 +231,8 @@ RUN \
 	if [ ! -d "models" ]; then \
 		echo "Downloading yolov3 weights..." && \
 		mkdir models && \
-		wget -O models/yolov3.weights https://pjreddie.com/media/files/yolov3$weightNameExtension.weights; \
+		wget -O models/yolov3.weights https://pjreddie.com/media/files/yolov3$weightNameExtension.weights &&\
+		touch ".weights${weightNameExtension}"; \
 	else \
 		echo "yolov3 weights found..."; \
 	fi; \


### PR DESCRIPTION
`docker-entrypoint.sh` references this check in order to download new weights if necessary.